### PR TITLE
w4-erges699-170-auth-types-bugfix

### DIFF
--- a/src/auth/auth.types.ts
+++ b/src/auth/auth.types.ts
@@ -1,9 +1,10 @@
 import { Request } from 'express';
+import { UserRole } from '../users/users.enums';
 
 export type JwtPayload = {
   sub: string;
   email: string;
-  role: string;
+  role: UserRole;
 };
 
 export type TAuthRequest = Request & {
@@ -13,6 +14,6 @@ export type TAuthRequest = Request & {
 export type UserFromRefreshToken = {
   id: string;
   email: string;
-  role: string;
+  role: UserRole;
   refreshToken: string;
 };


### PR DESCRIPTION
Поправить тип роли пользователя в auth/types.ts
https://github.com/Pr-month/SkillSwap_37_2/issues/170

Исправил:

- JwtPayload использует правильный enum UserRole (импортирован из ../users/users.enums).
- тип UserFromRefreshToken, заменил role: string на role: UserRole для согласованности с JwtPayload.