### PR TITLE
w4-erges699-139-sid-e2e-test-in-test-db

### DIFF
--- a/.env.test.local.example
+++ b/.env.test.local.example
@@ -1,0 +1,26 @@
+# App
+PORT=3000
+NODE_ENV=test
+JWT_SECRET=jwt-secret-test
+JWT_ACCESS_TOKEN_EXPIRES_IN=3600
+JWT_REFRESH_TOKEN_EXPIRES_IN=604800
+
+# Db
+DB_HOST=localhost
+DB_PORT=5432
+DB_USER=postgres
+DB_PASSWORD=root
+DB_NAME=skillswap_test
+
+# Jwt
+JWT_SECRET=your-super-secret-jwt-key-test
+JWT_EXPIRES_IN=1h
+JWT_REFRESH_SECRET=refresh-your-super-secret-jwt-key-test
+JWT_REFRESH_EXPIRES_IN=7d
+
+# Cors
+CORS_ORIGIN='*'
+
+# Admin
+ADMIN_EMAIL=admin@admin.ru
+ADMIN_PASSWORD=admin1234

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,7 @@
         "@types/node": "^22.10.7",
         "@types/passport-jwt": "^4.0.1",
         "@types/supertest": "^6.0.2",
+        "dotenv-cli": "^11.0.0",
         "eslint": "^9.18.0",
         "eslint-config-prettier": "^10.0.1",
         "eslint-plugin-prettier": "^5.2.2",
@@ -250,7 +251,6 @@
       "integrity": "sha512-UlLAnTPrFdNGoFtbSXwcGFQBtQZJCNjaN6hQNP3UPvuNXT1i82N26KL3dZeIpNalWywr9IuQuncaAfUaS1g6sQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -2300,7 +2300,6 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -2469,7 +2468,6 @@
       "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-11.1.3.tgz",
       "integrity": "sha512-ogEK+GriWodIwCw6buQ1rpcH4Kx+G7YQ9EwuPySI3rS05pSdtQ++UhucjusSI9apNidv+QURBztJkRecwwJQXg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "file-type": "21.0.0",
         "iterare": "1.2.1",
@@ -2517,7 +2515,6 @@
       "integrity": "sha512-5lTni0TCh8x7bXETRD57pQFnKnEg1T6M+VLE7wAmyQRIecKQU+2inRGZD+A4v2DC1I04eA0WffP0GKLxjOKlzw==",
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@nuxt/opencollective": "0.4.1",
         "fast-safe-stringify": "2.1.1",
@@ -2601,7 +2598,6 @@
       "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-11.1.3.tgz",
       "integrity": "sha512-hEDNMlaPiBO72fxxX/CuRQL3MEhKRc/sIYGVoXjrnw6hTxZdezvvM6A95UaLsYknfmcZZa/CdG1SMBZOu9agHQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cors": "2.8.5",
         "express": "5.1.0",
@@ -3027,7 +3023,6 @@
       "integrity": "sha512-Q5FsI3Cw0fGMXhmsg7c08i4EmXCrcl+WnAxb6LYOLHw4JFFC3yzmx9LaXZ7QMbA+JZXbigU2TirI7RAfO0Qlnw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@swc/counter": "^0.1.3",
         "@xhmikosr/bin-wrapper": "^13.0.5",
@@ -3100,7 +3095,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@swc/counter": "^0.1.3",
         "@swc/types": "^0.1.23"
@@ -3474,7 +3468,6 @@
       "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "*",
         "@types/json-schema": "*"
@@ -3637,7 +3630,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.16.3.tgz",
       "integrity": "sha512-sr4Xz74KOUeYadexo1r8imhRtlVXcs+j3XK3TcoiYk7B1t3YRVJgtaD3cwX73NYb71pmVuMLNRhJ9XKdoDB74g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -3811,7 +3803,6 @@
       "integrity": "sha512-kVIaQE9vrN9RLCQMQ3iyRlVJpTiDUY6woHGb30JDkfJErqrQEmtdWH3gV0PBAfGZgQXoqzXOO0T3K6ioApbbAA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.37.0",
         "@typescript-eslint/types": "8.37.0",
@@ -4778,7 +4769,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4792,6 +4782,7 @@
       "integrity": "sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.13.0"
       },
@@ -4828,7 +4819,6 @@
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -5366,7 +5356,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001726",
         "electron-to-chromium": "^1.5.173",
@@ -5627,7 +5616,6 @@
       "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "readdirp": "^4.0.1"
       },
@@ -5675,15 +5663,13 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.5.1.tgz",
       "integrity": "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/class-validator": {
       "version": "0.14.3",
       "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.14.3.tgz",
       "integrity": "sha512-rXXekcjofVN1LTOSw+u4u9WXVEUvNBVjORW154q/IdmYWy1nMbOU9aNtZB0t8m+FJQ9q91jlr2f9CwwUFdFMRA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/validator": "^13.15.3",
         "libphonenumber-js": "^1.11.1",
@@ -6260,6 +6246,22 @@
         "url": "https://dotenvx.com"
       }
     },
+    "node_modules/dotenv-cli": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv-cli/-/dotenv-cli-11.0.0.tgz",
+      "integrity": "sha512-r5pA8idbk7GFWuHEU7trSTflWcdBpQEK+Aw17UrSHjS6CReuhrrPcyC3zcQBPQvhArRHnBo/h6eLH1fkCvNlww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "dotenv": "^17.1.0",
+        "dotenv-expand": "^12.0.0",
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "dotenv": "cli.js"
+      }
+    },
     "node_modules/dotenv-expand": {
       "version": "12.0.3",
       "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-12.0.3.tgz",
@@ -6484,7 +6486,6 @@
       "integrity": "sha512-QldCVh/ztyKJJZLr4jXNUByx3gR+TDYZCRXEktiZoUR3PGy4qCmSbkxcIle8GEwGpb5JBZazlaJ/CxLidXdEbQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6546,7 +6547,6 @@
       "integrity": "sha512-zc1UmCpNltmVY34vuLRV61r1K27sWuX39E+uyUnY8xS2Bex88VV9cugG+UZbRSRGtGyFboj+D8JODyme1plMpw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -8131,7 +8131,6 @@
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -9802,7 +9801,6 @@
       "resolved": "https://registry.npmjs.org/passport/-/passport-0.7.0.tgz",
       "integrity": "sha512-cPLl+qZpSc+ireUvt+IzqbED1cHHkDoVYMo30jbJIdOOjQ1MQYZBPiNvmi8UM6lJuOpTPXJGZQk0DtC4y61MYQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "passport-strategy": "1.x.x",
         "pause": "0.0.1",
@@ -9947,7 +9945,6 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.19.0.tgz",
       "integrity": "sha512-QIcLGi508BAHkQ3pJNptsFz5WQMlpGbuBGBaIaXsWK8mel2kQ/rThYI+DbgjUvZrIr7MiuEuc9LcChJoEZK1xQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.11.0",
         "pg-pool": "^3.12.0",
@@ -10215,7 +10212,6 @@
       "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -10443,8 +10439,7 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
       "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/repeat-string": {
       "version": "1.6.1",
@@ -10639,7 +10634,6 @@
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -11501,7 +11495,6 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -11852,7 +11845,6 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -12013,7 +12005,6 @@
       "resolved": "https://registry.npmjs.org/typeorm/-/typeorm-0.3.28.tgz",
       "integrity": "sha512-6GH7wXhtfq2D33ZuRXYwIsl/qM5685WZcODZb7noOOcRMteM9KF2x2ap3H0EBjnSV0VO4gNAfJT5Ukp0PkOlvg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@sqltools/formatter": "^1.2.5",
         "ansis": "^4.2.0",
@@ -12257,7 +12248,6 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -12600,6 +12590,7 @@
       "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ajv": "^8.0.0"
       },
@@ -12618,6 +12609,7 @@
       "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3"
       },
@@ -12631,6 +12623,7 @@
       "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "esrecurse": "^4.3.0",
         "estraverse": "^4.1.1"
@@ -12645,6 +12638,7 @@
       "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "engines": {
         "node": ">=4.0"
       }
@@ -12654,7 +12648,8 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/webpack/node_modules/mime-db": {
       "version": "1.52.0",
@@ -12662,6 +12657,7 @@
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -12672,6 +12668,7 @@
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mime-db": "1.52.0"
       },
@@ -12685,6 +12682,7 @@
       "integrity": "sha512-Gn/JaSk/Mt9gYubxTtSn/QCV4em9mpAPiR1rqy/Ocu19u/G9J5WWdNoUT4SiV6mFC3y6cxyFcFwdzPM3FgxGAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/json-schema": "^7.0.9",
         "ajv": "^8.9.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
     "test:e2e": "jest --config ./test/jest-e2e.json",
-    "seed": "dotenv -e .env -- ts-node -r tsconfig-paths/register src/scripts/seeder.ts"
+    "seed": "dotenv -e .env -- ts-node -r tsconfig-paths/register src/scripts/seeder.ts",
+    "seed:test": "dotenv -e .env.test.local -- ts-node -r tsconfig-paths/register src/scripts/seeder-test.ts"
   },
   "dependencies": {
     "@nestjs/common": "^11.0.1",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "jest --config ./test/jest-e2e.json",
+    "test:e2e": "npm run seed:test && jest --config ./test/jest-e2e.json",
     "seed": "dotenv -e .env -- ts-node -r tsconfig-paths/register src/scripts/seeder.ts",
     "seed:test": "dotenv -e .env.test.local -- ts-node -r tsconfig-paths/register src/scripts/seeder-test.ts"
   },
@@ -58,6 +58,7 @@
     "@types/node": "^22.10.7",
     "@types/passport-jwt": "^4.0.1",
     "@types/supertest": "^6.0.2",
+    "dotenv-cli": "^11.0.0",
     "eslint": "^9.18.0",
     "eslint-config-prettier": "^10.0.1",
     "eslint-plugin-prettier": "^5.2.2",

--- a/src/scripts/seed-admin.ts
+++ b/src/scripts/seed-admin.ts
@@ -7,10 +7,8 @@ import * as bcrypt from 'bcrypt';
 dotenv.config();
 
 export async function seedAdmin() {
-  await AppDataSource.initialize();
   const userRepo = AppDataSource.getRepository(User);
 
-  try {
     const adminEmail = process.env.ADMIN_EMAIL || 'admin@admin.ru';
     const adminPassword = process.env.ADMIN_PASSWORD || 'admin1234';
 
@@ -44,14 +42,4 @@ export async function seedAdmin() {
 
     await userRepo.save(adminData);
     console.log(`Администратор создан с email: ${adminEmail}`);
-  } finally {
-    await AppDataSource.destroy();
-  }
-}
-
-if (require.main === module) {
-  seedAdmin().catch((e: unknown) => {
-    console.error('Ошибка при сидинге Администратора:', e);
-    process.exit(1);
-  });
-}
+  } 

--- a/src/scripts/seed-categories.ts
+++ b/src/scripts/seed-categories.ts
@@ -3,9 +3,6 @@ import { Category } from '../categories/entities/category.entity';
 import { CategoriesData } from './seed-categories.data';
 
 export async function seedCategories() {
-  try {
-    await AppDataSource.initialize();
-
     const categoryRepo = AppDataSource.getRepository(Category);
 
     if ((await categoryRepo.count()) > 0) {
@@ -28,11 +25,4 @@ export async function seedCategories() {
         });
       }
     }
-  } catch (err) {
-    console.error(err);
-  } finally {
-    if (AppDataSource.isInitialized) {
-      await AppDataSource.destroy();
-    }
-  }
-}
+  } 

--- a/src/scripts/seed-skills.ts
+++ b/src/scripts/seed-skills.ts
@@ -4,7 +4,6 @@ import { User } from '../users/entities/user.entity';
 import { Category } from '../categories/entities/category.entity';
 
 export async function seedSkills() {
-  await AppDataSource.initialize();
   const skillRepo = AppDataSource.getRepository(Skill);
   const userRepo = AppDataSource.getRepository(User);
   const categoryRepo = AppDataSource.getRepository(Category);
@@ -91,11 +90,4 @@ export async function seedSkills() {
 
   await skillRepo.save(testSkills);
   console.log(`Создано ${testSkills.length} тестовых навыков.`);
-
-  await AppDataSource.destroy();
 }
-
-seedSkills().catch((e) => {
-  console.error('Ошибка при сидинге навыков:', e);
-  process.exit(1);
-});

--- a/src/scripts/seed-users.ts
+++ b/src/scripts/seed-users.ts
@@ -4,71 +4,59 @@ import { UserRole, UserGender } from '../users/users.enums';
 import * as bcrypt from 'bcrypt';
 
 export async function seedUsers() {
-  await AppDataSource.initialize();
   const userRepo = AppDataSource.getRepository(User);
 
-  try {
-    const hashedPassword = await bcrypt.hash('password123', 10); // хеш для password123
+  const hashedPassword = await bcrypt.hash('password123', 10); // хеш для password123
 
-    const testUsers = [
-      {
-        name: 'Пользователь 1',
-        email: 'user1@test.com',
-        password: hashedPassword,
-        about: 'Тестовый пользователь 1',
-        birthdate: new Date('1995-05-15'),
-        city: 'Санкт-Петербург',
-        gender: UserGender.FEMALE,
-        avatar: 'useravatar1.png',
-        role: UserRole.USER,
-      },
-      {
-        name: 'Пользователь 2',
-        email: 'user2@test.com',
-        password: hashedPassword,
-        about: 'Тестовый пользователь 2',
-        birthdate: new Date('1992-08-22'),
-        city: 'Новосибирск',
-        gender: UserGender.MALE,
-        avatar: 'useravatar2.png',
-        role: UserRole.USER,
-      },
-      {
-        name: 'Пользователь 3',
-        email: 'user3@test.com',
-        password: hashedPassword,
-        about: 'Тестовый пользователь 3',
-        birthdate: new Date('1988-12-03'),
-        city: 'Екатеринбург',
-        gender: UserGender.FEMALE,
-        avatar: 'useravatar3.png',
-        role: UserRole.USER,
-      },
-    ];
+  const testUsers = [
+    {
+      name: 'Пользователь 1',
+      email: 'user1@test.com',
+      password: hashedPassword,
+      about: 'Тестовый пользователь 1',
+      birthdate: new Date('1995-05-15'),
+      city: 'Санкт-Петербург',
+      gender: UserGender.FEMALE,
+      avatar: 'useravatar1.png',
+      role: UserRole.USER,
+    },
+    {
+      name: 'Пользователь 2',
+      email: 'user2@test.com',
+      password: hashedPassword,
+      about: 'Тестовый пользователь 2',
+      birthdate: new Date('1992-08-22'),
+      city: 'Новосибирск',
+      gender: UserGender.MALE,
+      avatar: 'useravatar2.png',
+      role: UserRole.USER,
+    },
+    {
+      name: 'Пользователь 3',
+      email: 'user3@test.com',
+      password: hashedPassword,
+      about: 'Тестовый пользователь 3',
+      birthdate: new Date('1988-12-03'),
+      city: 'Екатеринбург',
+      gender: UserGender.FEMALE,
+      avatar: 'useravatar3.png',
+      role: UserRole.USER,
+    },
+  ];
 
-    for (const userData of testUsers) {
-      const existing = await userRepo.findOne({
-        where: { email: userData.email },
-      });
-      if (!existing) {
-        await userRepo.save(userData);
-        console.log(`Пользователь ${userData.email} создан.`);
-      } else {
-        console.log(
-          `Пользователь ${userData.email} уже существует, пропускаем.`,
-        );
-      }
+  for (const userData of testUsers) {
+    const existing = await userRepo.findOne({
+      where: { email: userData.email },
+    });
+    if (!existing) {
+      await userRepo.save(userData);
+      console.log(`Пользователь ${userData.email} создан.`);
+    } else {
+      console.log(
+        `Пользователь ${userData.email} уже существует, пропускаем.`,
+      );
     }
-
-    console.log('Сидинг тестовых пользователей завершён.');
-  } finally {
-    await AppDataSource.destroy();
   }
-}
 
-if (require.main === module) {
-  seedUsers().catch((e) => {
-    console.error('Ошибка при сидинге пользователей:', e);
-    process.exit(1);
-  });
+  console.log('Сидинг тестовых пользователей завершён.');
 }

--- a/src/scripts/seeder-test.ts
+++ b/src/scripts/seeder-test.ts
@@ -1,0 +1,76 @@
+import { AppDataSource } from '../config/db.config';
+import { seedAdmin } from './seed-admin';
+import { seedUsers } from './seed-users';
+import { seedSkills } from './seed-skills';
+import { seedCategories } from './seed-categories';
+
+async function cleanDatabase() {
+  console.log('Очистка базы данных...');
+  const queryRunner = AppDataSource.createQueryRunner();
+
+  await queryRunner.connect();
+  await queryRunner.startTransaction();
+
+  try {
+    // Отключаем триггеры для внешних ключей (для PostgreSQL)
+    await queryRunner.query('SET session_replication_role = replica;');
+
+    // Удаляем данные из таблиц в порядке, обратном зависимостям
+    await queryRunner.query(`TRUNCATE TABLE "requests" CASCADE;`);
+    await queryRunner.query(`TRUNCATE TABLE "skills" CASCADE;`);
+    await queryRunner.query(`TRUNCATE TABLE "users" CASCADE;`);
+    await queryRunner.query(`TRUNCATE TABLE "categories" CASCADE;`);
+
+    // Включаем обратно
+    await queryRunner.query('SET session_replication_role = origin;');
+
+    await queryRunner.commitTransaction();
+    console.log('База данных очищена.');
+  } catch (error) {
+    await queryRunner.rollbackTransaction();
+    console.error('Ошибка при очистке базы данных:', error);
+    throw error;
+  } finally {
+    await queryRunner.release();
+  }
+}
+
+async function seederTest() {
+  try {
+    await AppDataSource.initialize();
+
+    await cleanDatabase();
+
+    console.log('Запуск сидинга категорий...');
+    await seedCategories();
+    console.log('Сидинг категорий завершён.');
+
+    console.log('Запуск сидинга администратора...');
+    await seedAdmin();
+    console.log('Сидинг администратора завершён.');
+
+    console.log('Запуск сидинга тестовых пользователей...');
+    await seedUsers();
+    console.log('Сидинг тестовых пользователей завершён.');
+
+    console.log('Запуск сидинга навыков...');
+    await seedSkills();
+    console.log('Сидинг навыков завершён.');
+
+    console.log('Все тестовые сидинги успешно выполнены.');
+  } catch (error) {
+    console.error('Ошибка в тестовом сидинге:', error);
+    process.exit(1);
+  } finally {
+    if (AppDataSource.isInitialized) {
+      await AppDataSource.destroy();
+    }
+  }
+}
+
+if (require.main === module) {
+  seederTest().catch((e) => {
+    console.error(e);
+    process.exit(1);
+  });
+}

--- a/src/scripts/seeder.ts
+++ b/src/scripts/seeder.ts
@@ -1,19 +1,14 @@
 import { seedAdmin } from './seed-admin';
-import { seedUsers } from './seed-users';
-import { seedSkills } from './seed-skills';
+import { seedCategories } from './seed-categories';
 
 async function seeder() {
+  console.log('Запуск сидинга категорий...');
+  await seedCategories();
+  console.log('Сидинг категорий завершён.');
+
   console.log('Запуск сидинга администратора...');
   await seedAdmin();
   console.log('Сидинг администратора завершён.');
-
-  console.log('Запуск сидинга тестовых пользователей...');
-  await seedUsers();
-  console.log('Сидинг тестовых пользователей завершён.');
-
-  console.log('Запуск сидинга навыков...');
-  await seedSkills();
-  console.log('Сидинг навыков завершён.');
 
   console.log('Все сидинги успешно выполнены.');
 }

--- a/test/jest-e2e.json
+++ b/test/jest-e2e.json
@@ -8,5 +8,6 @@
   },
   "moduleNameMapper": {
     "^src/(.*)$": "<rootDir>/../src/$1"
-  }
+  },
+  "setupFilesAfterEnv": ["<rootDir>/setup.ts"]
 }

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -1,0 +1,5 @@
+import { config } from 'dotenv';
+import { resolve } from 'path';
+
+const envFile = resolve(__dirname, '..', '.env.test.local');
+config({ path: envFile });


### PR DESCRIPTION
Настроить сидинг и запуск e2e тестов в отдельной бд
https://github.com/Pr-month/SkillSwap_37_2/issues/139

Создал файл src/scripts/seeder-test.ts с функцией очистки базы данных (TRUNCATE CASCADE) и последовательным запуском всех сидов (категории, админ, пользователи, навыки);
Исправил src/scripts/seeder.ts — оставлены только сиды категорий и админа;
В package.json добавлен скрипт seed:test для запуска тестового сидера с использованием .env.test.local;
Создал файл .env.test.local.example с примером конфигурации для тестовой базы данных (DB_NAME=skillswap_test);
Настроил e2e тесты для использования отдельной БД:
Создал test/setup.ts, который загружает переменные окружения из .env.test.local;
Обновил test/jest-e2e.json с добавлением setupFilesAfterEnv для автоматической загрузки конфигурации перед запуском тестов.