### PR TITLE
w4-erges699-211-add-alias-unit-tests

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,0 +1,22 @@
+import { pathsToModuleNameMapper } from 'ts-jest';
+
+interface TsConfig {
+  compilerOptions: {
+    paths?: Record<string, string[]>;
+  };
+}
+
+import tsConfig from './tsconfig.json';
+const compilerOptions = (tsConfig as TsConfig).compilerOptions;
+
+export default {
+  moduleFileExtensions: ['js', 'json', 'ts'],
+  rootDir: '.',
+  testRegex: '.*\\.spec\\.ts$',
+  transform: {
+    '^.+\\.(t|j)s$': 'ts-jest',
+  },
+  moduleNameMapper: pathsToModuleNameMapper(compilerOptions?.paths ?? {}, {
+    prefix: '<rootDir>/',
+  }),
+};

--- a/package.json
+++ b/package.json
@@ -13,10 +13,10 @@
     "start:debug": "nest start --debug --watch",
     "start:prod": "node dist/main",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
-    "test": "jest",
-    "test:watch": "jest --watch",
-    "test:cov": "jest --coverage",
-    "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
+    "test": "jest --config jest.config.ts",
+    "test:watch": "jest --watch --config jest.config.ts",
+    "test:cov": "jest --coverage --config jest.config.ts",
+    "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand --config jest.config.ts",
     "test:e2e": "npm run seed:test && jest --config ./test/jest-e2e.json",
     "seed": "dotenv -e .env -- ts-node -r tsconfig-paths/register src/scripts/seeder.ts",
     "seed:test": "dotenv -e .env.test.local -- ts-node -r tsconfig-paths/register src/scripts/seeder-test.ts"
@@ -77,22 +77,5 @@
     "tsconfig-paths": "^4.2.0",
     "typescript": "^5.7.3",
     "typescript-eslint": "^8.20.0"
-  },
-  "jest": {
-    "moduleFileExtensions": [
-      "js",
-      "json",
-      "ts"
-    ],
-    "rootDir": "src",
-    "testRegex": ".*\\.spec\\.ts$",
-    "transform": {
-      "^.+\\.(t|j)s$": "ts-jest"
-    },
-    "collectCoverageFrom": [
-      "**/*.(t|j)s"
-    ],
-    "coverageDirectory": "../coverage",
-    "testEnvironment": "node"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,10 +6,17 @@
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
     "target": "ES2023",
     "sourceMap": true,
     "outDir": "./dist",
     "baseUrl": "./",
+    "resolveJsonModule": true,
+    "paths": {
+      "src/*": [
+        "src/*"
+      ]
+    },
     "incremental": true,
     "skipLibCheck": true,
     "strictNullChecks": true,


### PR DESCRIPTION
Настроить алиасы для unit тестов
https://github.com/Pr-month/SkillSwap_37_2/issues/211

Настроил алиасы для unit тестов:

- Создал файл jest.config.ts в корне проекта с конфигурацией, включающей moduleNameMapper на основе paths из tsconfig.json.
- Обновил tsconfig.json: добавлены "resolveJsonModule": true, "esModuleInterop": true и секция "paths" с алиасом "src/*": ["src/*"].
- Обновил скрипты в package.json: test, test:watch, test:cov, test:debug теперь используют --config jest.config.ts. Секция "jest" удалена из package.json во избежание конфликтов.