### PR TITLE
dev-erges699-unit-tests-fix

### DIFF
--- a/src/auth/auth.service.spec.ts
+++ b/src/auth/auth.service.spec.ts
@@ -7,6 +7,11 @@ import { jwtConfig } from '../config/jwt.config';
 import { UnauthorizedException } from '@nestjs/common';
 import { UserGender, UserRole } from '../users/users.enums';
 
+jest.mock('bcrypt', () => ({
+  compare: jest.fn(),
+  hash: jest.fn(),
+}));
+
 describe('AuthService', () => {
   let service: AuthService;
   let usersService: {
@@ -82,12 +87,8 @@ describe('AuthService', () => {
       usersService.findByEmail.mockResolvedValue(user);
       usersService.updateRefreshToken.mockResolvedValue(undefined);
 
-      jest
-        .spyOn(bcrypt, 'compare')
-        .mockImplementation(() => Promise.resolve(true));
-      jest
-        .spyOn(bcrypt, 'hash')
-        .mockImplementation(() => Promise.resolve('hashed-refresh-token'));
+      (bcrypt.compare as jest.Mock).mockResolvedValue(true);
+      (bcrypt.hash as jest.Mock).mockResolvedValue('hashed-refresh-token');
 
       jwtService.signAsync
         .mockResolvedValueOnce('access-token')
@@ -137,9 +138,7 @@ describe('AuthService', () => {
         role: 'USER',
       });
 
-      jest
-        .spyOn(bcrypt, 'compare')
-        .mockImplementation(() => Promise.resolve(false));
+      (bcrypt.compare as jest.Mock).mockResolvedValue(false);
 
       await expect(
         service.login({
@@ -161,10 +160,9 @@ describe('AuthService', () => {
       });
       usersService.updateRefreshToken.mockResolvedValue(undefined);
 
-      jest
-        .spyOn(bcrypt, 'hash')
-        .mockImplementationOnce(() => Promise.resolve('hashed-password'))
-        .mockImplementationOnce(() => Promise.resolve('hashed-refresh-token'));
+      (bcrypt.hash as jest.Mock)
+        .mockResolvedValueOnce('hashed-password')
+        .mockResolvedValueOnce('hashed-refresh-token');
 
       jwtService.signAsync
         .mockResolvedValueOnce('access-token')
@@ -215,9 +213,7 @@ describe('AuthService', () => {
         .mockResolvedValueOnce('access-token')
         .mockResolvedValueOnce('refresh-token');
 
-      jest
-        .spyOn(bcrypt, 'hash')
-        .mockImplementationOnce(() => Promise.resolve('hashed-refresh-token'));
+      (bcrypt.hash as jest.Mock).mockResolvedValueOnce('hashed-refresh-token');
 
       const result = await service.refresh({
         id: '1',

--- a/src/cities/cities.controller.spec.ts
+++ b/src/cities/cities.controller.spec.ts
@@ -5,10 +5,23 @@ import { CitiesService } from './cities.service';
 describe('CitiesController', () => {
   let controller: CitiesController;
 
+  const mockCitiesService = {
+    findAll: jest.fn(),
+    findOne: jest.fn(),
+    create: jest.fn(),
+    update: jest.fn(),
+    remove: jest.fn(),
+  };
+
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [CitiesController],
-      providers: [CitiesService],
+      providers: [
+        {
+          provide: CitiesService,
+          useValue: mockCitiesService,
+        },
+      ],
     }).compile();
 
     controller = module.get<CitiesController>(CitiesController);

--- a/src/cities/cities.service.spec.ts
+++ b/src/cities/cities.service.spec.ts
@@ -1,12 +1,28 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
 import { CitiesService } from './cities.service';
+import { City } from './entities/city.entity';
 
 describe('CitiesService', () => {
   let service: CitiesService;
 
+  const mockRepository = {
+    find: jest.fn(),
+    findOneBy: jest.fn(),
+    create: jest.fn(),
+    save: jest.fn(),
+    remove: jest.fn(),
+  };
+
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [CitiesService],
+      providers: [
+        CitiesService,
+        {
+          provide: getRepositoryToken(City),
+          useValue: mockRepository,
+        },
+      ],
     }).compile();
 
     service = module.get<CitiesService>(CitiesService);

--- a/src/files/files.validator.spec.ts
+++ b/src/files/files.validator.spec.ts
@@ -55,7 +55,7 @@ describe('MaxFileSizeValidator', () => {
   it('should build correct error message', () => {
     const validator = new MaxFileSizeValidator({ maxSize: 2 * 1024 * 1024 });
     expect(validator.buildErrorMessage()).toBe(
-      'Размер файла не может привышать 2Мб',
+      'Размер файла не может превышать 2Мб',
     );
   });
 });

--- a/src/notifications/notifications.gateway.spec.ts
+++ b/src/notifications/notifications.gateway.spec.ts
@@ -1,12 +1,31 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { NotificationsGateway } from './notifications.gateway';
+import { appConfig } from '../config/app.config';
+
+jest.mock('../auth/guards/ws-gwt-acces.guard', () => ({
+  WsJwtGuard: jest.fn().mockImplementation(() => ({
+    canActivate: jest.fn().mockReturnValue(true),
+  })),
+}));
 
 describe('NotificationsGateway', () => {
   let gateway: NotificationsGateway;
 
+  const mockConfig = {
+    cors: {
+      origin: '*',
+    },
+  };
+
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [NotificationsGateway],
+      providers: [
+        NotificationsGateway,
+        {
+          provide: appConfig.KEY,
+          useValue: mockConfig,
+        },
+      ],
     }).compile();
 
     gateway = module.get<NotificationsGateway>(NotificationsGateway);

--- a/src/notifications/notifications.service.spec.ts
+++ b/src/notifications/notifications.service.spec.ts
@@ -1,12 +1,23 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { NotificationsService } from './notifications.service';
+import { NotificationsGateway } from './notifications.gateway';
 
 describe('NotificationsService', () => {
   let service: NotificationsService;
 
+  const mockNotificationsGateway = {
+    sendNotification: jest.fn(),
+  };
+
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [NotificationsService],
+      providers: [
+        NotificationsService,
+        {
+          provide: NotificationsGateway,
+          useValue: mockNotificationsGateway,
+        },
+      ],
     }).compile();
 
     service = module.get<NotificationsService>(NotificationsService);

--- a/src/skills/skills.service.spec.ts
+++ b/src/skills/skills.service.spec.ts
@@ -1,6 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { Repository, SelectQueryBuilder, DeleteResult } from 'typeorm';
 import { SkillsService } from './skills.service';
 import { Skill } from './entities/skill.entity';
 import { NotFoundException, ForbiddenException } from '@nestjs/common';
@@ -143,7 +143,7 @@ describe('SkillsService', () => {
         getMany: jest.fn().mockResolvedValue(mockSkills),
       };
       mockRepository.createQueryBuilder.mockReturnValue(
-        mockQueryBuilder as any,
+        mockQueryBuilder as unknown as SelectQueryBuilder<Skill>,
       );
 
       const result = await service.findAll(query);
@@ -177,7 +177,7 @@ describe('SkillsService', () => {
         getMany: jest.fn().mockResolvedValue(mockSkills),
       };
       mockRepository.createQueryBuilder.mockReturnValue(
-        mockQueryBuilder as any,
+        mockQueryBuilder as unknown as SelectQueryBuilder<Skill>,
       );
 
       await service.findAll(query);
@@ -201,7 +201,7 @@ describe('SkillsService', () => {
         getMany: jest.fn(),
       };
       mockRepository.createQueryBuilder.mockReturnValue(
-        mockQueryBuilder as any,
+        mockQueryBuilder as unknown as SelectQueryBuilder<Skill>,
       );
 
       await expect(service.findAll(query)).rejects.toThrow(NotFoundException);
@@ -252,7 +252,9 @@ describe('SkillsService', () => {
         ...mockSkill,
         owner: { ...mockOwner, id: 'other-id', email: 'other@example.com' },
       };
-      mockRepository.findOne.mockResolvedValue(differentOwnerSkill as Skill);
+      mockRepository.findOne.mockResolvedValue(
+        differentOwnerSkill as unknown as Skill,
+      );
 
       await expect(
         service.findOneAndCheckOwner(mockSkill.id, mockUser),
@@ -269,8 +271,10 @@ describe('SkillsService', () => {
       };
       const updatedSkill = { ...skillWithOwner, ...updateSkillDto };
 
-      mockRepository.findOne.mockResolvedValue(skillWithOwner as Skill);
-      mockRepository.save.mockResolvedValue(updatedSkill as Skill);
+      mockRepository.findOne.mockResolvedValue(
+        skillWithOwner as unknown as Skill,
+      );
+      mockRepository.save.mockResolvedValue(updatedSkill as unknown as Skill);
 
       const result = await service.update(
         mockSkill.id,
@@ -299,7 +303,9 @@ describe('SkillsService', () => {
         ...mockSkill,
         owner: { ...mockOwner, id: 'other-id' },
       };
-      mockRepository.findOne.mockResolvedValue(skillWithOtherOwner as Skill);
+      mockRepository.findOne.mockResolvedValue(
+        skillWithOtherOwner as unknown as Skill,
+      );
 
       await expect(service.update(mockSkill.id, {}, 'user-id')).rejects.toThrow(
         ForbiddenException,
@@ -310,7 +316,10 @@ describe('SkillsService', () => {
   describe('remove', () => {
     it('should delete skill if found', async () => {
       mockRepository.findOneBy.mockResolvedValue(mockSkill);
-      mockRepository.delete.mockResolvedValue({ affected: 1, raw: {} } as any);
+      mockRepository.delete.mockResolvedValue({
+        affected: 1,
+        raw: {},
+      } as unknown as DeleteResult);
 
       const result = await service.remove(mockSkill.id);
 

--- a/src/skills/skills.service.spec.ts
+++ b/src/skills/skills.service.spec.ts
@@ -74,6 +74,7 @@ describe('SkillsService', () => {
       findOne: jest.fn(),
       findOneBy: jest.fn(),
       remove: jest.fn(),
+      delete: jest.fn(),
     } as unknown as jest.Mocked<Repository<Skill>>;
 
     const module: TestingModule = await Test.createTestingModule({
@@ -307,9 +308,25 @@ describe('SkillsService', () => {
   });
 
   describe('remove', () => {
-    it('should return a message', () => {
-      const result = service.remove('some-id');
-      expect(result).toBe('This action removes a #some-id skill');
+    it('should delete skill if found', async () => {
+      mockRepository.findOneBy.mockResolvedValue(mockSkill);
+      mockRepository.delete.mockResolvedValue({ affected: 1, raw: {} } as any);
+
+      const result = await service.remove(mockSkill.id);
+
+      expect(mockRepository.findOneBy).toHaveBeenCalledWith({
+        id: mockSkill.id,
+      });
+      expect(mockRepository.delete).toHaveBeenCalledWith(mockSkill.id);
+      expect(result).toEqual({ affected: 1, raw: {} });
+    });
+
+    it('should throw NotFoundException if skill not found', async () => {
+      mockRepository.findOneBy.mockResolvedValue(null);
+
+      await expect(service.remove('non-existent-id')).rejects.toThrow(
+        NotFoundException,
+      );
     });
   });
 });

--- a/src/users/users.service.spec.ts
+++ b/src/users/users.service.spec.ts
@@ -7,6 +7,7 @@ import { Skill } from '../skills/entities/skill.entity';
 import { Category } from '../categories/entities/category.entity';
 import { appConfig } from '../config/app.config';
 import * as bcrypt from 'bcrypt';
+import { CreateUserDto } from './dto/create-user.dto';
 // import { UserRole, UserGender } from './users.enums';
 
 jest.mock('bcrypt', () => ({
@@ -93,6 +94,7 @@ describe('UsersService', () => {
         name: 'Test',
         email: 'test@test.com',
         password: 'oldHash',
+        role: 'USER',
       };
       mockRepository.findOneBy.mockResolvedValue(user);
       mockRepository.save.mockResolvedValue(user);
@@ -110,7 +112,12 @@ describe('UsersService', () => {
         mockConfig.hashSalt,
       );
       expect(mockRepository.save).toHaveBeenCalled();
-      expect(result).toEqual({ id: 1, name: 'Test', email: 'test@test.com' });
+      expect(result).toEqual({
+        id: 1,
+        name: 'Test',
+        email: 'test@test.com',
+        role: 'USER',
+      });
     });
 
     it('should throw BadRequestException when old password is wrong', async () => {
@@ -175,7 +182,7 @@ describe('UsersService', () => {
 
   describe('create', () => {
     it('should create user', async () => {
-      const dto = {
+      const dto: CreateUserDto = {
         name: 'Test',
         email: 'test@test.com',
         password: 'pass123',
@@ -190,7 +197,7 @@ describe('UsersService', () => {
       mockRepository.create.mockReturnValue({});
       mockRepository.save.mockResolvedValue(createdUser);
 
-      const result = await service.create(dto as any);
+      const result = await service.create(dto);
 
       expect(mockRepository.create).toHaveBeenCalledWith();
       expect(mockRepository.save).toHaveBeenCalled();

--- a/src/users/users.service.spec.ts
+++ b/src/users/users.service.spec.ts
@@ -9,6 +9,11 @@ import { appConfig } from '../config/app.config';
 import * as bcrypt from 'bcrypt';
 // import { UserRole, UserGender } from './users.enums';
 
+jest.mock('bcrypt', () => ({
+  compare: jest.fn(),
+  hash: jest.fn(),
+}));
+
 describe('UsersService', () => {
   let service: UsersService;
 
@@ -91,8 +96,8 @@ describe('UsersService', () => {
       };
       mockRepository.findOneBy.mockResolvedValue(user);
       mockRepository.save.mockResolvedValue(user);
-      (jest.spyOn(bcrypt, 'compare') as jest.Mock).mockResolvedValue(true);
-      (jest.spyOn(bcrypt, 'hash') as jest.Mock).mockResolvedValue('newHash');
+      (bcrypt.compare as jest.Mock).mockResolvedValue(true);
+      (bcrypt.hash as jest.Mock).mockResolvedValue('newHash');
 
       const result = await service.changePassword('1', {
         oldPassword: 'oldPass',
@@ -116,7 +121,7 @@ describe('UsersService', () => {
         password: 'oldHash',
       };
       mockRepository.findOneBy.mockResolvedValue(user);
-      (jest.spyOn(bcrypt, 'compare') as jest.Mock).mockResolvedValue(false);
+      (bcrypt.compare as jest.Mock).mockResolvedValue(false);
 
       await expect(
         service.changePassword('1', {


### PR DESCRIPTION
Unit тест Notifcations
https://github.com/Pr-month/SkillSwap_37_2/issues/244
Unit тест Cities
https://github.com/Pr-month/SkillSwap_37_2/issues/245
Сломался Unit тест auth.service.spec.ts
https://github.com/Pr-month/SkillSwap_37_2/issues/246
Сломался Unit тест users.service.spec.ts
https://github.com/Pr-month/SkillSwap_37_2/issues/247
Сломался Unit тест files.validator.spec.ts
https://github.com/Pr-month/SkillSwap_37_2/issues/248

Исправлены unit тесты:

1. auth.service.spec.ts, users.service.spec.ts — добавлены моки для модуля bcrypt, заменены jest.spyOn на прямое использование моков.
2. тесты Cities, Notifications:
   - В cities.service.spec.ts и cities.controller.spec.ts добавил моки репозитория и сервиса.
   - В notifications.service.spec.ts добавил мок NotificationsGateway.
   - В notifications.gateway.spec.ts добавил моки конфигурации и guard'а WsJwtGuard.
4. тест remove в skills.service.spec.ts

После исправлений все 21 test suite проходят успешно, всего 108 тестов. 
Unit тесты работают без ошибок.